### PR TITLE
Fix visualization bug

### DIFF
--- a/src/components/Visualizer/Visualizer.component.jsx
+++ b/src/components/Visualizer/Visualizer.component.jsx
@@ -23,21 +23,72 @@ class Visualizer extends React.Component {
         super(props);
 
         this.state = {
-            sketch
+            sketch,
+            canvasWidth:0
         };
+
+        //create a reference and reference to
+        //<div className={classes.visualizer}></div> in jsx
+        //so we can get react node back 
+        this.visualizerRef = React.createRef();
+    }
+
+    componentDidMount(){
+
+        //we listen window resize event and call
+        // onWindowResize method
+        window.addEventListener('resize', this.onWindowResize)
+        this.onWindowResize();
+    }
+
+    componentWillUnmount(){
+
+        //we remove window resize event
+        window.removeEventListener('resize', this.onWindowResize);
+    }
+
+    //calculate new canvas width when window's size changed
+    //calculation should base on parent element
+    onWindowResize = ()=>{
+       
+        //get style properties from parent 
+        const style = window.getComputedStyle(this.visualizerRef.current.parentElement, null);
+
+        //get this style properties from <div className={classes.visualizer}></div>
+        const thisStyle = window.getComputedStyle(this.visualizerRef.current, null);
+
+        //get padding, border and margin width for <div className={classes.visualizer}></div>
+        const thisPaddingWidth = parseFloat(thisStyle.getPropertyValue('padding-left')) + parseFloat(thisStyle.getPropertyValue('padding-right'));
+        const thisBorderWidth = parseFloat(thisStyle.getPropertyValue('border-left')) + parseFloat(thisStyle.getPropertyValue('border-left'));
+        const thisMarginWidth = parseFloat(thisStyle.getPropertyValue('margin-left')) + parseFloat(thisStyle.getPropertyValue('margin-right'));
+
+        //get padding, border and margin width  from parent 
+        const paddingWidth = parseFloat(style.getPropertyValue('padding-left')) + parseFloat(style.getPropertyValue('padding-right'));
+        const borderWidth = parseFloat(style.getPropertyValue('border-left')) + parseFloat(style.getPropertyValue('border-left'));
+        const marginWidth = parseFloat(style.getPropertyValue('margin-left')) + parseFloat(style.getPropertyValue('margin-right'));
+
+        //calcualte new canvas width
+        const newCanvasWidth = parseFloat(style.getPropertyValue('width')) - 
+        paddingWidth  - thisPaddingWidth -  
+        borderWidth  -  thisBorderWidth -
+        marginWidth - thisMarginWidth;
+        
+        this.setState({canvasWidth:newCanvasWidth})
+
     }
 
     render() {
         const { volume, isPlaying, uploadedSong } = this.props;
-        const { sketch } = this.state;
+        const { sketch, canvasWidth } = this.state;
 
         return (
-            <div className={classes.visualizer}>
+            <div className={classes.visualizer} ref={this.visualizerRef}>
                 <P5Wrapper
                     sketch={sketch}
                     volume={volume}
                     isPlaying={isPlaying}
                     uploadedSong={uploadedSong}
+                    canvasWidth={canvasWidth}
                 />
             </div>
         );

--- a/src/components/Visualizer/Visualizer.module.scss
+++ b/src/components/Visualizer/Visualizer.module.scss
@@ -2,4 +2,5 @@
     padding: 1rem;
     margin: 0 auto;
     border: 0.1rem black dotted;
+    width:70%;//must have width otherwise canvas will only shrink instead of grow
 }

--- a/src/pages/App/App.js
+++ b/src/pages/App/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 // import SoundPlayer from '../../components/SoundPlayer/SoundPlayer.component';
-// import Visualizer from '../../components/Visualizer/Visualizer.component';
+import Visualizer from '../../components/Visualizer/Visualizer.component';
 import PlayerBar from '../../components/PlayerBar/PlayerBar';
 import classes from './App.module.scss';
 
@@ -72,18 +72,18 @@ class App extends React.Component {
             isSongLoaded,
             volume,
             isPlaying,
-            // onSongEnd
+            onSongEnd
         } = this.state;
         return (
             <div className={classes.pageContainer}>
-                {/* <div className={classes.visualmusic}>
+                <div className={classes.visualmusic}>
                     <Visualizer
                         volume={volume}
                         isPlaying={isPlaying}
                         uploadedSong={uploadedSong}
                         onSongEnd={onSongEnd}
                     />
-                </div> */}
+                </div>
                 <div className={classes.bar}>
                     <PlayerBar
                         volume={volume}

--- a/src/pages/App/App.module.scss
+++ b/src/pages/App/App.module.scss
@@ -5,9 +5,12 @@
     font-size: 1rem;
 }
 
-.page-container {
+.pageContainer {
     position: relative;
     min-height: 100vh;
+    min-width: 100vw;
+    width: 100%;
+    height: 100%;
   }
   
 .bar {

--- a/src/pages/App/App.module.scss
+++ b/src/pages/App/App.module.scss
@@ -5,12 +5,9 @@
     font-size: 1rem;
 }
 
-.pageContainer {
+.page-container {
     position: relative;
     min-height: 100vh;
-    min-width: 100vw;
-    width: 100%;
-    height: 100%;
   }
   
 .bar {

--- a/src/vendor/sketches/sketch.js
+++ b/src/vendor/sketches/sketch.js
@@ -9,7 +9,7 @@ export default function sketch(p) {
     let volume;
     let isPlaying = false;
 
-    const width = 900;
+    let width = 900;
     const height = 500;
     const divisions = 5;
     const speed = 1;
@@ -27,6 +27,12 @@ export default function sketch(p) {
 
     //Custom redraw that will trigger upon state change
     p.myCustomRedrawAccordingToNewPropsHandler = function(props) {
+        //We need to resize canvas
+        //and set width property to new width
+        //so drawing will bease on this new width
+        width = props.canvasWidth;
+        p.resizeCanvas(props.canvasWidth, height);
+
         if (song) {
             if (song.isLoaded()) {
                 volume = props.volume;


### PR DESCRIPTION
[Trello task](https://trello.com/c/EA0R5xXT/103-fix-visualization-bug)

### Where is the issue coming from?
My guess the issue is because p5's canvas is fixed width and height. In sketch.js you can see width and height is fixed to 900 and 500 respectively. Due to this fact, visualizer''s width and height is always 900 and 500, no matter what screen size is. In additon, p5-wrapper has it own padding or margin so visualizer 's width and height maybe a little different from 900 and 500.

### My idea to fix it
- If canvas is able to resize when screen size changed then in my opinion, the issue is solved.
- Visualizer capture screen resize event and calculate canvas new size base on it's parent element and pass new size to canvas then canvas resize and redraw.

### What have I changed
- Uncomment everything related to visualizer.
- Change Visualizer.compoent.jsx and Visualizer.module.scss
- sketch.js

### What is fixed?
- On different width of screen playerbar is 100% width of screen 

### ToDo
- Make visualizer flexible on height when screen height changed

### Some thing need to concern
- The performance. Every time screen resize, it need to pull all style properties and recalculate again.
