### PR TITLE
Song current progress

### DIFF
--- a/src/assets/PlayerBarAssets/pause-icon.svg
+++ b/src/assets/PlayerBarAssets/pause-icon.svg
@@ -1,0 +1,13 @@
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="24"
+        viewBox="0 0 18 24"
+    >
+        <path
+            fill="rgba(255, 255, 255, 0.75)"
+            fillRule="evenodd"
+            d="M0 0h6v24H0zM12 0h6v24h-6z"
+            className="pause-icon"
+        />
+    </svg>

--- a/src/components/PlayerBar/PlayerBar.js
+++ b/src/components/PlayerBar/PlayerBar.js
@@ -7,8 +7,7 @@
  2. Play/Pause audio.
  3. Download visualization
  4. Change volume
-
- TODO: - Allow users to control the part of the song to be played
+ 5. Control the part of the song to be played
 
  ************************************************************/
 
@@ -36,7 +35,8 @@ export default function PlayerBar(props) {
         isPlaying,
         onVolumeChange,
         songEnded,
-        currentTime
+        currentTime,
+        onCueTimeChange
     } = props;
 
     // Set formated duration
@@ -91,6 +91,15 @@ export default function PlayerBar(props) {
                         <div
                             className={classes.progress}
                             style={sliderProgressWidth}
+                        />
+                        <input
+                            className={classes.rangeInput}
+                            type="range"
+                            min="0"
+                            max={duration}
+                            step="1"
+                            name="cue"
+                            onClick={onCueTimeChange}
                         />
                     </div>
                     <span className={classes.progressTime}>

--- a/src/components/PlayerBar/PlayerBar.js
+++ b/src/components/PlayerBar/PlayerBar.js
@@ -5,9 +5,9 @@
  Current features:
  1. Load audio file.
  2. Play/Pause audio.
+ 3. Download visualization
+ 4. Change volume
 
- TODO: - Change volume
- TODO: - Get song duration
  TODO: - Get current progress
  TODO: - Allow users to control the part of the song to be played
 
@@ -39,19 +39,8 @@ const pauseButton = (
     </svg>
 );
 
-/***********************************************************
- Parameters (src/pages/App/App.js):
- state:
- 1. volume
- 2. isPlaying
- 3. uploadedSong
- 4. isSongLoaded
-
- functions:
- 1.  onPlayPress
- *************************************************************/
-
 export default function PlayerBar(props) {
+    // Props from (src/pages/App/App.js):
     const {
         uploadedSong,
         duration,
@@ -59,12 +48,12 @@ export default function PlayerBar(props) {
         playPressed,
         isPlaying,
         onVolumeChange,
-        songEnded
-        // currentTime
+        songEnded,
+        currentTime
     } = props;
 
+    // Change play button to loading svg when loading on p5 sound
     let actionButton;
-
     if (isPlaying) {
         actionButton = pauseButton;
     } else {
@@ -86,12 +75,11 @@ export default function PlayerBar(props) {
                     {playPressed ? actionButton : <PlayIcon />}
                 </div>
                 <div className={classes.controls}>
-                    <span className={classes.progressTime}>0:00</span>
+                    <span className={classes.progressTime}>{currentTime}</span>
                     <div className={classes.slider}>
                         <div className={classes.progress} />
                     </div>
                     <span className={classes.progressTime}>
-                        {/* 0:00{' '} */}
                         {uploadedSong ? duration : '0:00'}
                     </span>
                 </div>

--- a/src/components/PlayerBar/PlayerBar.js
+++ b/src/components/PlayerBar/PlayerBar.js
@@ -8,38 +8,25 @@
  3. Download visualization
  4. Change volume
 
- TODO: - Get current progress
  TODO: - Allow users to control the part of the song to be played
 
  ************************************************************/
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { ReactComponent as SnapshotIcon } from '../../assets/PlayerBarAssets/snapshot-icon-white-dark.svg';
 import { ReactComponent as VolumeIcon } from '../../assets/PlayerBarAssets/volume-icon.svg';
 import { ReactComponent as PlayIcon } from '../../assets/PlayerBarAssets/play-icon.svg';
+import { ReactComponent as PauseIcon } from '../../assets/PlayerBarAssets/pause-icon.svg';
 import { ReactComponent as SongIcon } from '../../assets/PlayerBarAssets/song-icon.svg';
 import { ReactComponent as RollingIcon } from '../../assets/LoadingAssets/Rolling.svg';
 import UploadButton from './UploadButton/UploadButton';
 import classes from './PlayerBar.module.scss';
 import DownloadButton from './DownloadButton/DownloadButton';
 
-const pauseButton = (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="18"
-        height="24"
-        viewBox="0 0 18 24"
-    >
-        <path
-            fill="rgba(255, 255, 255, 0.75)"
-            fillRule="evenodd"
-            d="M0 0h6v24H0zM12 0h6v24h-6z"
-            className="pause-icon"
-        />
-    </svg>
-);
-
 export default function PlayerBar(props) {
+    const [formatedDuration, setFormatedDuration] = useState('0:00');
+    const [formatedCurrentTime, setFormatedCurrentTime] = useState('0:00');
+
     // Props from (src/pages/App/App.js):
     const {
         uploadedSong,
@@ -52,10 +39,32 @@ export default function PlayerBar(props) {
         currentTime
     } = props;
 
+    // Set formated duration
+    useEffect(() => {
+        setFormatedDuration(getTime(duration));
+    }, [duration]);
+
+    // Set formated current time
+    useEffect(() => {
+        setFormatedCurrentTime(getTime(currentTime));
+    }, [currentTime]);
+
+    // Format time (eg. 140 to 2:20)
+    const getTime = dur => {
+        return (
+            Math.floor(dur / 60) + ':' + ('0' + Math.floor(dur % 60)).slice(-2)
+        );
+    };
+
+    // Update the width for the progress slider base on the current time
+    const sliderProgressWidth = {
+        width: `${(100 * currentTime) / duration}%`
+    };
+
     // Change play button to loading svg when loading on p5 sound
     let actionButton;
     if (isPlaying) {
-        actionButton = pauseButton;
+        actionButton = <PauseIcon />;
     } else {
         actionButton = <RollingIcon />;
     }
@@ -75,12 +84,17 @@ export default function PlayerBar(props) {
                     {playPressed ? actionButton : <PlayIcon />}
                 </div>
                 <div className={classes.controls}>
-                    <span className={classes.progressTime}>{currentTime}</span>
+                    <span className={classes.progressTime}>
+                        {formatedCurrentTime}
+                    </span>
                     <div className={classes.slider}>
-                        <div className={classes.progress} />
+                        <div
+                            className={classes.progress}
+                            style={sliderProgressWidth}
+                        />
                     </div>
                     <span className={classes.progressTime}>
-                        {uploadedSong ? duration : '0:00'}
+                        {formatedDuration}
                     </span>
                 </div>
                 <div className={classes.volume}>

--- a/src/components/PlayerBar/PlayerBar.js
+++ b/src/components/PlayerBar/PlayerBar.js
@@ -33,6 +33,7 @@ export default function PlayerBar(props) {
         onPlayPress,
         playPressed,
         isPlaying,
+        volume,
         onVolumeChange,
         songEnded,
         currentTime,
@@ -112,9 +113,10 @@ export default function PlayerBar(props) {
                         <input
                             type="range"
                             min="0"
-                            max="10"
-                            step="0.5"
+                            max="1"
+                            step="0.1"
                             name="volume"
+                            value={volume}
                             className={classes.volumeSlider}
                             onChange={onVolumeChange}
                         ></input>

--- a/src/components/PlayerBar/PlayerBar.module.scss
+++ b/src/components/PlayerBar/PlayerBar.module.scss
@@ -98,13 +98,13 @@
         border-radius: 5px;
         height: 10px;
         margin: 0 16px;
+        overflow: hidden;
 
         .progress {
             background-color: rgba(255, 255, 255, 0.8);
             border-radius: inherit;
             position: absolute;
             pointer-events: none;
-            width: 0;
             height: 100%;
         }
     }
@@ -176,6 +176,7 @@
 @media only screen and (max-width: 900px) {
     .playerBarRight {
         width: 30%;
+
         .download {
             width: 50%;
         }
@@ -192,6 +193,7 @@
 }
 
 @media screen and (max-width: 700px) {
+
     .icon,
     .volumeButton,
     .playerBarRight .download {

--- a/src/components/PlayerBar/PlayerBar.module.scss
+++ b/src/components/PlayerBar/PlayerBar.module.scss
@@ -38,7 +38,6 @@
     cursor: pointer;
     position: relative;
     border-radius: 5px;
-    height: 10px;
     margin: 0 16px;
 }
 

--- a/src/components/PlayerBar/PlayerBar.module.scss
+++ b/src/components/PlayerBar/PlayerBar.module.scss
@@ -93,7 +93,6 @@
     .slider {
         flex-grow: 1;
         background-color: rgba(255, 255, 255, 0.25);
-        cursor: pointer;
         position: relative;
         border-radius: 5px;
         height: 10px;
@@ -106,6 +105,12 @@
             position: absolute;
             pointer-events: none;
             height: 100%;
+        }
+
+        .rangeInput {
+            width: 100%;
+            opacity: 0;
+            cursor: pointer;
         }
     }
 }

--- a/src/components/Visualizer/Visualizer.component.jsx
+++ b/src/components/Visualizer/Visualizer.component.jsx
@@ -13,68 +13,51 @@
 
 ************************************************************/
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import classes from './Visualizer.module.scss';
 import P5Wrapper from 'react-p5-wrapper';
 import sketch from '../../vendor/sketches/sketch';
 import Measure from 'react-measure';
 
-class Visualizer extends React.Component {
-    constructor(props) {
-        super(props);
+const Visualizer = React.memo(props => {
+    const [canvasWidth, setCanvasWidth] = useState(100);
+    const [canvasHeight, setCanvasHeight] = useState(100);
 
-        this.state = {
-            sketch,
-            canvasWidth: 100,
-            canvasHeight: 100
-        };
-    }
-
-    onResize = content => {
+    const onResize = content => {
         const { width, height, left, top } = content;
         const cWidth = width - left;
         const cHeight = height - top;
-        this.setState({ canvasWidth: cWidth, canvasHeight: cHeight });
+        setCanvasWidth(cWidth);
+        setCanvasHeight(cHeight);
     };
 
-    render() {
-        const {
-            volume,
-            playPressed,
-            uploadedSong,
-            audioRef,
-            downloadVisual,
-            blob
-        } = this.props;
-        const { sketch, canvasWidth, canvasHeight } = this.state;
+    const { volume, playPressed, uploadedSong, downloadVisual, blob } = props;
 
-        return (
-            <Measure
-                offset
-                onResize={content => {
-                    this.onResize(content.offset);
-                }}
-            >
-                {({ measureRef }) => (
-                    <div ref={measureRef} className={classes.visualizer}>
-                        <P5Wrapper
-                            sketch={sketch}
-                            volume={volume}
-                            playPressed={playPressed}
-                            uploadedSong={uploadedSong}
-                            canvasWidth={canvasWidth}
-                            canvasHeight={canvasHeight}
-                            audioRef={audioRef}
-                            downloadVisual={downloadVisual}
-                            blob={blob}
-                            dispatch={useDispatch()}
-                        />
-                    </div>
-                )}
-            </Measure>
-        );
-    }
-}
+    return (
+        <Measure
+            offset
+            onResize={content => {
+                onResize(content.offset);
+            }}
+        >
+            {({ measureRef }) => (
+                <div ref={measureRef} className={classes.visualizer}>
+                    <P5Wrapper
+                        sketch={sketch}
+                        volume={volume}
+                        playPressed={playPressed}
+                        uploadedSong={uploadedSong}
+                        canvasWidth={canvasWidth}
+                        canvasHeight={canvasHeight}
+                        downloadVisual={downloadVisual}
+                        blob={blob}
+                        dispatch={useDispatch()}
+                    />
+                </div>
+            )}
+        </Measure>
+    );
+});
 
 export default Visualizer;

--- a/src/components/Visualizer/Visualizer.component.jsx
+++ b/src/components/Visualizer/Visualizer.component.jsx
@@ -32,7 +32,14 @@ const Visualizer = React.memo(props => {
         setCanvasHeight(cHeight);
     };
 
-    const { volume, playPressed, uploadedSong, downloadVisual, blob } = props;
+    const {
+        volume,
+        cueTime,
+        playPressed,
+        uploadedSong,
+        downloadVisual,
+        blob
+    } = props;
 
     return (
         <Measure
@@ -53,6 +60,7 @@ const Visualizer = React.memo(props => {
                         downloadVisual={downloadVisual}
                         blob={blob}
                         dispatch={useDispatch()}
+                        cueTime={cueTime}
                     />
                 </div>
             )}

--- a/src/pages/App/App.js
+++ b/src/pages/App/App.js
@@ -16,6 +16,7 @@ export default function App({ song }) {
     const [isPlaying, setIsPlaying] = useState(false);
     const [duration, setDuration] = useState(null);
     const [currentTime, setCurrentTime] = useState(null);
+    const [cueTime, setCueTime] = useState(0);
     const [volume, setVolume] = useState(0.5);
     const [togglePanel, setTogglePanel] = useState(false);
     const [songEnded, setSongEnded] = useState(false);
@@ -78,6 +79,11 @@ export default function App({ song }) {
         setCurrentTime(e.target.currentTime);
     };
 
+    // Set cue time when users click on the progress slider (/PlayerBar.js)
+    const onCueTimeChange = e => {
+        setCueTime(e.target.value);
+    };
+
     /********************************************
         Handle hamburger toggle callback. When 
         hamburger toggle's state changed, we need
@@ -108,6 +114,7 @@ export default function App({ song }) {
                             uploadedSong={uploadedSong && uploadedSong.url}
                             blob={blob}
                             downloadVisual={songEnded && downloadState}
+                            cueTime={cueTime}
                         />
                     </div>
                     <div
@@ -138,6 +145,7 @@ export default function App({ song }) {
                         uploadedSong={uploadedSong}
                         duration={duration}
                         songEnded={songEnded}
+                        onCueTimeChange={onCueTimeChange}
                     />
                 </div>
             </div>

--- a/src/pages/App/App.js
+++ b/src/pages/App/App.js
@@ -14,8 +14,8 @@ export default function App({ song }) {
     const [uploadedSong, setUploadedSong] = useState(null);
     const [playPressed, setPlayPressed] = useState(false);
     const [isPlaying, setIsPlaying] = useState(false);
-    const [duration, setDuration] = useState('0:00');
-    const [currentTime, setCurrentTime] = useState('0:00');
+    const [duration, setDuration] = useState(null);
+    const [currentTime, setCurrentTime] = useState(null);
     const [volume, setVolume] = useState(0.5);
     const [togglePanel, setTogglePanel] = useState(false);
     const [songEnded, setSongEnded] = useState(false);
@@ -67,23 +67,15 @@ export default function App({ song }) {
         setSongEnded(true);
     };
 
-    /********************************************
-        Uploaded audio file duration converted in
-        to proper format e.g. 3:14
-    ********************************************/
+    // Set duration from audio event
     const handleMetadata = event => {
         const duration = event.currentTarget.duration;
-        setDuration(getTime(duration));
+        setDuration(duration);
     };
 
-    const getTime = dur => {
-        return (
-            Math.floor(dur / 60) + ':' + ('0' + Math.floor(dur % 60)).slice(-2)
-        );
-    };
-
-    const currentTimeHandler = e => {
-        setCurrentTime(getTime(e.target.currentTime));
+    // Set currentTime from audio event (onTimeUpdate)
+    const onTimeChange = e => {
+        setCurrentTime(e.target.currentTime);
     };
 
     /********************************************
@@ -132,7 +124,7 @@ export default function App({ song }) {
                         onEnded={onSongEnd}
                         onLoadedMetadata={handleMetadata}
                         onPlay={onAudioPlay}
-                        onTimeUpdate={currentTimeHandler}
+                        onTimeUpdate={onTimeChange}
                     ></audio>
                 </div>
                 <div className={classes.bar}>

--- a/src/pages/App/App.js
+++ b/src/pages/App/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 // import Error from '../../components/Error/Error';
 // import SoundPlayer from '../../components/SoundPlayer/SoundPlayer.component';
@@ -15,14 +15,13 @@ export default function App({ song }) {
     const [playPressed, setPlayPressed] = useState(false);
     const [isPlaying, setIsPlaying] = useState(false);
     const [duration, setDuration] = useState('0:00');
+    const [currentTime, setCurrentTime] = useState('0:00');
     const [volume, setVolume] = useState(0.5);
     const [togglePanel, setTogglePanel] = useState(false);
     const [songEnded, setSongEnded] = useState(false);
     const [blob, setBlob] = useState(null);
 
     const downloadState = useSelector(state => state.download.downloadState);
-    // Refs
-    const audioRef = useRef(null);
 
     // Effects
     useEffect(() => {
@@ -83,6 +82,10 @@ export default function App({ song }) {
         );
     };
 
+    const currentTimeHandler = e => {
+        setCurrentTime(getTime(e.target.currentTime));
+    };
+
     /********************************************
         Handle hamburger toggle callback. When 
         hamburger toggle's state changed, we need
@@ -112,7 +115,6 @@ export default function App({ song }) {
                             playPressed={playPressed}
                             uploadedSong={uploadedSong && uploadedSong.url}
                             blob={blob}
-                            audioRef={audioRef.current}
                             downloadVisual={songEnded && downloadState}
                         />
                     </div>
@@ -127,18 +129,15 @@ export default function App({ song }) {
                 <div>
                     <audio
                         id="audio"
-                        ref={audioRef}
                         onEnded={onSongEnd}
                         onLoadedMetadata={handleMetadata}
                         onPlay={onAudioPlay}
+                        onTimeUpdate={currentTimeHandler}
                     ></audio>
                 </div>
                 <div className={classes.bar}>
                     <PlayerBar
-                        currentTime={
-                            audioRef.current &&
-                            getTime(audioRef.current.currentTime)
-                        }
+                        currentTime={currentTime}
                         volume={volume}
                         onVolumeChange={onVolumeChange}
                         onPlayPress={onPlayPress}

--- a/src/vendor/sketches/sketch.js
+++ b/src/vendor/sketches/sketch.js
@@ -100,6 +100,7 @@ export default function sketch(p) {
         amplitude = new p5.Amplitude(); // for the ellipses
         p.noFill();
         p.stroke(0, 100);
+        initAudioStream();
     };
 
     //Custom redraw that will trigger upon state change
@@ -144,8 +145,6 @@ export default function sketch(p) {
 
                 // Add audio source
                 audio.src = URL.createObjectURL(props.blob);
-                // Initialize audio context
-                audio.oncanplay = initAudioStream;
 
                 // Start p5 visualization when press the play button
                 if (props.playPressed) {

--- a/src/vendor/sketches/sketch.js
+++ b/src/vendor/sketches/sketch.js
@@ -23,9 +23,22 @@ export default function sketch(p) {
     let dest;
     let canvasStream;
     let audioStream;
-    let audio;
     let mediaRecorder;
     let recordedChunks = [];
+    let audio = document.getElementById('audio');
+
+    function initAudioStream(evt) {
+        if (!audioCtx) {
+            // Create a new audio context
+            audioCtx = new AudioContext();
+            // create a stream from the AudioContext
+            dest = audioCtx.createMediaStreamDestination();
+            audioStream = dest.stream;
+            // connect the audio element's output to the stream
+            sourceNode = audioCtx.createMediaElementSource(audio);
+            sourceNode.connect(dest);
+        }
+    }
 
     function recordStream() {
         if (canvasStream) {
@@ -91,19 +104,6 @@ export default function sketch(p) {
 
     //Custom redraw that will trigger upon state change
     p.myCustomRedrawAccordingToNewPropsHandler = function(props) {
-        function initAudioStream(evt) {
-            if (!audioCtx) {
-                // Create a new audio context
-                audioCtx = new AudioContext();
-                // create a stream from the AudioContext
-                dest = audioCtx.createMediaStreamDestination();
-                audioStream = dest.stream;
-                // connect the audio element's output to the stream
-                sourceNode = audioCtx.createMediaElementSource(props.audioRef);
-                sourceNode.connect(dest);
-            }
-        }
-
         // Function that get called when a song is loaded
         function loaded() {
             playPressed = props.playPressed;
@@ -142,8 +142,7 @@ export default function sketch(p) {
                 recordedChunks = [];
                 canvasStream = null;
 
-                // Get the audio element from the DOM and add the blob as the source
-                audio = props.audioRef;
+                // Add audio source
                 audio.src = URL.createObjectURL(props.blob);
                 // Initialize audio context
                 audio.oncanplay = initAudioStream;

--- a/src/vendor/sketches/sketch.js
+++ b/src/vendor/sketches/sketch.js
@@ -148,9 +148,11 @@ export default function sketch(p) {
         //We need to resize canvas
         //and set width property to new width
         //so drawing will base on this new width
-        width = props.canvasWidth;
-        height = props.canvasHeight;
-        p.resizeCanvas(width, height);
+        if (width !== props.canvasWidth || height !== props.canvasHeight) {
+            width = props.canvasWidth;
+            height = props.canvasHeight;
+            p.resizeCanvas(width, height);
+        }
 
         // Check for new uploaded song
         if (song) {


### PR DESCRIPTION
**Commit 1:**

- Refactor Visualizer.component.jsx to React Hooks component.

- Memoize Visualizer.component.jsx so it is not updated every second (onTimeUpdate).

- Get rid of  the Audio reference in App.js

- The Audio reference is now directly grabbed in sketch.js

- Refactor sketch.js

**Commit 2:**

- Move pause-icon into the assets folder

- Move time formatting into PlayerBar.js

- Calculate and set the width of the progress slider base on the current time of a song

**Commit 3:**

- Enables users to change the current time of a song

**Commit 4:**

- Remove unnecessary rendering if height/width did not change:
Before the fix, every time a prop changed the canvas resize was triggered which was rerendering the canvas background.